### PR TITLE
Fix import error

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,8 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-python.python",
-		"ms-python.vscode-pylance"
+		"ms-python.vscode-pylance",
+		"redhat.ansible"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
Change the way to import module in order to import the desired module correctly.
    
In recent versions of ansible, "import authconfig" imports this module  instead of authoconfig under the /usr/share/authconfig, so this module will not work as reported in #3.
    
fixes #3 